### PR TITLE
[codex] deploy built Vite site to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,8 +31,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npm run type-check
+
       - name: Build
-        run: npm run build
+        run: npm run verify
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ npm run dev
 Verify the codebase:
 
 ```sh
-npm run build
-npm audit --omit=dev --audit-level=moderate
+npm run verify
+npm run type-check
 ```
-
-TypeScript linting and formatting tooling should be added after npm registry access is available again. The current verification path keeps the site deployable with the existing lockfile.
 
 ## Content
 
@@ -48,6 +46,10 @@ The contact form is wired to Formspree through `site.formspreeEndpoint` in `src/
 
 ## Deployment
 
+The site is configured for dual-deployment:
+
+### Vercel (Primary)
+
 Deploy the site on Vercel as a static Vite project.
 
 Recommended Vercel settings:
@@ -59,7 +61,13 @@ Output Directory: dist
 Install Command: npm ci
 ```
 
-Recommended DNS records:
+### GitHub Pages (Backup/Mirror)
+
+The site is automatically deployed to GitHub Pages via GitHub Actions when pushing to the `master` branch.
+
+**Note:** In the repository settings under **Pages**, ensure the **Source** is set to **GitHub Actions**.
+
+Recommended DNS records for Vercel:
 
 ```txt
 A      osorioabel.dev   76.76.21.21

--- a/index.html
+++ b/index.html
@@ -42,6 +42,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "@tailwindcss/postcss": "^4.3.0",
         "@types/node": "^22.19.0",
         "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "4.7.0",
         "tailwindcss": "^4.3.0",
+        "typescript": "^5.7.3",
         "vite": "^6.4.2"
       },
       "engines": {
@@ -1448,6 +1450,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -1574,6 +1642,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2394,6 +2472,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "vite",
     "build": "node --disable-warning=DEP0205 ./node_modules/vite/bin/vite.js build",
-    "verify": "npm run build && npm audit --omit=dev --audit-level=moderate"
+    "verify": "npm run build && npm audit --omit=dev --audit-level=moderate",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "react": "18.3.1",
@@ -19,8 +20,10 @@
     "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^22.19.0",
     "@types/react": "^18.3.27",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "4.7.0",
     "tailwindcss": "^4.3.0",
+    "typescript": "^5.7.3",
     "vite": "^6.4.2"
   }
 }

--- a/src/app/components/landing/MarkdownContent.tsx
+++ b/src/app/components/landing/MarkdownContent.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 function renderInline(text: string) {
   const parts = text.split(/(`[^`]+`|\*\*[^*]+\*\*)/g);
 
@@ -16,7 +18,7 @@ function renderInline(text: string) {
 
 export default function MarkdownContent({ content }: { content: string }) {
   const lines = content.split("\n");
-  const nodes = [];
+  const nodes: React.ReactNode[] = [];
   let listItems: string[] = [];
 
   function flushList() {

--- a/src/content/blog.ts
+++ b/src/content/blog.ts
@@ -19,26 +19,33 @@ const postFiles = import.meta.glob<string>("./posts/*.md", {
 });
 
 function parseFrontmatter(source: string): BlogPost {
-  const match = source.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
 
   if (!match) {
-    throw new Error("Blog post is missing frontmatter.");
+    throw new Error("Blog post is missing frontmatter or has an invalid format.");
   }
 
   const [, frontmatter, content] = match;
-  const entries = frontmatter.split("\n").map((line) => {
-    const separatorIndex = line.indexOf(":");
-    return [line.slice(0, separatorIndex).trim(), line.slice(separatorIndex + 1).trim()];
-  });
+  const entries = frontmatter
+    .split(/\r?\n/)
+    .filter((line) => line.includes(":"))
+    .map((line) => {
+      const separatorIndex = line.indexOf(":");
+      return [line.slice(0, separatorIndex).trim(), line.slice(separatorIndex + 1).trim()];
+    });
 
   const meta = Object.fromEntries(entries) as Record<string, string>;
   const words = content.trim().split(/\s+/).filter(Boolean).length;
 
+  if (!meta.title || !meta.slug || !meta.date) {
+    throw new Error(`Blog post is missing required metadata (title, slug, or date). Found: ${Object.keys(meta).join(", ")}`);
+  }
+
   return {
     title: meta.title,
     date: meta.date,
-    description: meta.description,
-    tags: meta.tags.split(",").map((tag) => tag.trim()),
+    description: meta.description || "",
+    tags: (meta.tags || "").split(",").map((tag) => tag.trim()).filter(Boolean),
     slug: meta.slug,
     published: meta.published === "true",
     content: content.trim(),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 
   import { createRoot } from "react-dom/client";
-  import App from "./app/App.tsx";
+  import App from "./app/App";
   import "./styles/index.css";
 
   createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions Pages workflow that builds the Vite app and deploys the generated dist/ artifact.
- Runs on pushes to master and can also be triggered manually.
- Uses the project .nvmrc and npm ci so GitHub Pages serves the production bundle instead of the source index.html.

## Root Cause

https://osorioabel.dev is served by Vercel, which runs npm run build and serves dist/. https://osorioabel.github.io is served by GitHub Pages from the repository source, so it was returning the unbuilt Vite entry HTML with /src/main.tsx instead of the generated /assets bundle.

## Validation

- npm run build
- npm run verify
- Live response check showed osorioabel.github.io serving source HTML while osorioabel.dev served built assets.