### PR TITLE
[codex] harden deploy workflow and navigation cleanup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run type-check
 
       - name: Build
-        run: npm run verify
+        run: npm run build
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -52,3 +52,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=moderate

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ npm run verify
 npm run type-check
 ```
 
+`npm run build` suppresses Node warning `DEP0205` because the current Tailwind CSS compiler still calls Node's deprecated `module.register()` API on newer Node runtimes. The project pins Node 22 for deployment; remove this suppression after Tailwind replaces that internal call.
+
 ## Content
 
 Site profile, services, projects, experience, and social links live in `src/content/site.ts`.
@@ -66,6 +68,8 @@ Install Command: npm ci
 The site is automatically deployed to GitHub Pages via GitHub Actions when pushing to the `master` branch.
 
 **Note:** In the repository settings under **Pages**, ensure the **Source** is set to **GitHub Actions**.
+
+The Pages deployment workflow runs type checking and the production build before publishing `dist/`. The production dependency audit runs as a separate job so transient npm audit availability does not block publishing a successfully built static site.
 
 Recommended DNS records for Vercel:
 

--- a/src/app/components/landing/BlogPostPage.tsx
+++ b/src/app/components/landing/BlogPostPage.tsx
@@ -10,7 +10,7 @@ export default function BlogPostPage({ post }: { post: BlogPost }) {
       <main className="px-6 py-16 md:px-12 md:py-24 lg:px-20">
         <article className="mx-auto max-w-4xl">
           <a
-            href="/#blog"
+            href="#blog"
             className="mb-10 inline-flex text-sm font-semibold text-brand transition-colors hover:text-brand-dark"
           >
             Back to writing

--- a/src/app/components/landing/MarkdownContent.tsx
+++ b/src/app/components/landing/MarkdownContent.tsx
@@ -19,24 +19,26 @@ function renderInline(text: string) {
 export default function MarkdownContent({ content }: { content: string }) {
   const lines = content.split("\n");
   const nodes: React.ReactNode[] = [];
-  let listItems: string[] = [];
+  let listItems: Array<{ item: string; lineIndex: number }> = [];
 
   function flushList() {
     if (listItems.length === 0) {
       return;
     }
 
+    const listStartIndex = listItems[0]?.lineIndex ?? nodes.length;
+
     nodes.push(
-      <ul key={`list-${nodes.length}`} className="space-y-2">
-        {listItems.map((item) => (
-          <li key={item}>{renderInline(item)}</li>
+      <ul key={`list-${listStartIndex}`} className="space-y-2">
+        {listItems.map(({ item, lineIndex }) => (
+          <li key={`list-item-${lineIndex}`}>{renderInline(item)}</li>
         ))}
       </ul>,
     );
     listItems = [];
   }
 
-  lines.forEach((line) => {
+  lines.forEach((line, lineIndex) => {
     if (!line.trim()) {
       flushList();
       return;
@@ -45,7 +47,7 @@ export default function MarkdownContent({ content }: { content: string }) {
     if (line.startsWith("## ")) {
       flushList();
       nodes.push(
-        <h2 key={line} className="pt-6 text-2xl font-semibold text-slate-950">
+        <h2 key={`heading-2-${lineIndex}`} className="pt-6 text-2xl font-semibold text-slate-950">
           {renderInline(line.slice(3))}
         </h2>,
       );
@@ -55,7 +57,7 @@ export default function MarkdownContent({ content }: { content: string }) {
     if (line.startsWith("# ")) {
       flushList();
       nodes.push(
-        <h1 key={line} className="text-4xl font-bold tracking-tight text-slate-950">
+        <h1 key={`heading-1-${lineIndex}`} className="text-4xl font-bold tracking-tight text-slate-950">
           {renderInline(line.slice(2))}
         </h1>,
       );
@@ -63,13 +65,13 @@ export default function MarkdownContent({ content }: { content: string }) {
     }
 
     if (line.startsWith("- ")) {
-      listItems.push(line.slice(2));
+      listItems.push({ item: line.slice(2), lineIndex });
       return;
     }
 
     flushList();
     nodes.push(
-      <p key={line} className="text-base leading-8 text-slate-700">
+      <p key={`paragraph-${lineIndex}`} className="text-base leading-8 text-slate-700">
         {renderInline(line)}
       </p>,
     );


### PR DESCRIPTION
## Summary

- Keeps GitHub Pages deploy focused on type checking and building the production bundle.
- Moves production dependency audit into a separate workflow job so audit availability does not block a valid static deploy.
- Makes the blog detail back link hash-relative instead of root-relative.
- Replaces markdown-rendered content keys with line-index based keys to avoid duplicate React keys for repeated text.
- Documents the Tailwind DEP0205 build warning workaround and when it can be removed.

## Validation

- npm run type-check
- npm run build
- npm run verify
- Served dist/ locally and smoke-tested the home page plus Blog hash navigation with no browser warnings or errors.

## Note

All current markdown posts are unpublished, so the blog-detail back-link path was reviewed by code and kept deployment-path agnostic, but there is no currently published blog detail page to click through without changing content publication state.